### PR TITLE
Use thinner WebLogic client library to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN mkdir -p ${SSO_HOME}/libs && \
     cd ${SSO_HOME}/libs && \
     curl ${ARTIFACTORY_BASE_URL}/libs-release/com/staffware/libssoJNI/11.4.1/libssoJNI-11.4.1.so -o libssoJNI.so && \
     curl ${ARTIFACTORY_BASE_URL}/libs-release/com/staffware/ssoRMI/11.4.1/ssoRMI-11.4.1.jar -o ssoRMI.jar && \
-    curl ${ARTIFACTORY_BASE_URL}/local-ch-release/com/oracle/weblogic/wlfullclient/12.2.1.4/wlfullclient-12.2.1.4.jar -o wlfullclient.jar && \
+    curl ${ARTIFACTORY_BASE_URL}/local-ch-release/com/oracle/weblogic/wlthint3client/12.2.1.4/wlthint3client-12.2.1.4.jar -o wlthint3client.jar && \
     chmod 750 ${SSO_HOME}/*.sh
 
 CMD ["bash"]

--- a/ssodaemon/ssodaemon.sh
+++ b/ssodaemon/ssodaemon.sh
@@ -7,7 +7,7 @@ timestamp() {
   done
 }
 
-export CLASSPATH=/sso:/sso/libs/ssoRMI.jar:/sso/libs/wlfullclient.jar
+export CLASSPATH=/sso:/sso/libs/ssoRMI.jar:/sso/libs/wlthint3client.jar
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/sso/libs
 
 VMARGS="-Dname=SSOServerFactory -Djava.security.policy=/sso/ssodaemon.policy -Xms128m -Xmx256m -classpath $CLASSPATH"
@@ -23,8 +23,6 @@ LOG_FILE="${LOGS_DIR}/${HOSTNAME}-ssodaemon-$(date +'%Y-%m-%d_%H-%M-%S').log"
 
 while :
 do
-  echo ${ADMIN_PASSWORD} 
-  echo ${HOST_SERVER} 
   /usr/java/jdk-8/bin/java -d64 $VMARGS $CLASS $ARGS  
 
   echo "========================="


### PR DESCRIPTION
Now uses the wlthint3client.jar (9MB) instead of the wlfullclient.jar (114MB)