### PR TITLE
Add watcher code to handle case where WebLogic is restarted

### DIFF
--- a/ssodaemon/Watcher.java
+++ b/ssodaemon/Watcher.java
@@ -1,0 +1,19 @@
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+class Watcher {
+    public static void main(String[] args) {
+        System.out.println("Watcher: obtaining reference to object " + args[0]); 
+        
+        try {
+           Context context = new InitialContext(); 
+           context.lookup(args[0]);
+        } 
+        catch (NamingException e) {
+            System.out.println("Watcher: error obtaining reference to object " + args[0]);
+            System.exit(1); 
+        }
+        System.exit(0);
+    }
+}

--- a/ssodaemon/Watcher.java
+++ b/ssodaemon/Watcher.java
@@ -2,6 +2,15 @@ import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 
+/**
+* This Watcher class provides a way to check whether an object is available in a remote JNDI tree.
+* It takes a single parameter which is the name/path of an object in the JNDI tree
+* It then obtains a context using connection details defined externally via jndi.properties
+* It then uses the context to obtain a reference to the remote object, using the supplied name/path
+* If there is any error whilst obtaing the reference or creating the context then it exits with a return code of 1
+* If there is no error and the object reference is obtained, it exits with a return code of 0
+*/
+
 class Watcher {
     public static void main(String[] args) {
         System.out.println("Watcher: obtaining reference to object " + args[0]); 

--- a/ssodaemon/ssodaemon.sh
+++ b/ssodaemon/ssodaemon.sh
@@ -17,18 +17,25 @@ CLASS=com.staffware.sso.rmi.rsServerFactoryImpl
 # Set the vars in the jndi.properties file
 envsubst < jndi.properties.template > jndi.properties
 
+# Compile the Watcher class
+/usr/java/jdk-8/bin/javac Watcher.java 
+
 LOGS_DIR=/sso/logs/ssodaemon
 mkdir -p ${LOGS_DIR}
 LOG_FILE="${LOGS_DIR}/${HOSTNAME}-ssodaemon-$(date +'%Y-%m-%d_%H-%M-%S').log"
 
 while :
 do
+  # Launch watcher process
+  /sso/watcher.sh &
+
+  # Attempt to bind the SSOServerFactory
   /usr/java/jdk-8/bin/java -d64 $VMARGS $CLASS $ARGS  
 
   echo "========================="
   echo "SSO Server Factory Exited >>>  on ${HOST_SERVER} "
   echo "========================="
 
-  sleep 10
+  sleep 30
 done 2>&1 | timestamp >> ${LOG_FILE}
 

--- a/ssodaemon/watcher.sh
+++ b/ssodaemon/watcher.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# This scripts checks for the presence of a java SSOServerFactory process
+# and checks that the ssoServerFactory object can be obtained from WebLogic
+# 
+# If there is no SSOServerFactory process, the script exits
+# If there is a process, the script tries to connect to WebLogic using the Watcher java class
+## If the reference to the ssoServerFactory can be obtained, the script waits and then repeats the check for the process etc
+## If the reference to the ssoServerFactory can't be obtained, the script kills the SSOServerFactory process and exits
+#
+# Killing of the SSOServerFactory process will cause a new watcher instance to be created in the parent ssodaemon.sh script,
+# and another attempt will be made to bind the ssoServerFactory to WebLogic
+
+# Wait to give the parent process time to successfully bind to WebLogic
+sleep 10
+
+while :
+do
+  # Check for java SSOServerFactory process
+  SSO_PID=$(ps -ef | grep SSOServerFactory | grep -v grep | awk '{print $2}')
+
+  if [ ${SSO_PID}x == "x" ]; then
+    echo "Watcher: no SSOServerFactory process found, so exiting.."
+    exit 0
+  fi
+
+  /usr/java/jdk-8/bin/java -cp /sso:/sso/libs/wlthint3client.jar Watcher ssoServerFactory
+  WATCHER_EXIT_CODE=$?
+
+  if [ ${WATCHER_EXIT_CODE} -ne 0 ]; then
+    echo "Watcher: failed to obtain reference so killing SSOServerFactory and exiting.."
+    kill ${SSO_PID}
+    exit 0
+  fi
+
+  echo "Watcher: reference obtained, so sleeping.."
+  sleep 30
+done
+

--- a/ssodaemon/watcher.sh
+++ b/ssodaemon/watcher.sh
@@ -5,8 +5,8 @@
 # 
 # If there is no SSOServerFactory process, the script exits
 # If there is a process, the script tries to connect to WebLogic using the Watcher java class
-## If the reference to the ssoServerFactory can be obtained, the script waits and then repeats the check for the process etc
-## If the reference to the ssoServerFactory can't be obtained, the script kills the SSOServerFactory process and exits
+# If the reference to the ssoServerFactory can be obtained, the script waits and then repeats the check for the process etc
+# If the reference to the ssoServerFactory can't be obtained, the script kills the SSOServerFactory process and exits
 #
 # Killing of the SSOServerFactory process will cause a new watcher instance to be created in the parent ssodaemon.sh script,
 # and another attempt will be made to bind the ssoServerFactory to WebLogic


### PR DESCRIPTION
Adds a watcher.sh script and a java class to regularly check if the ssoServerFactory is obtainable.  If it isn't then the SSOServerFactory java process is killed, so that it is recreated.  This is to handle the case where WebLogic is restarted, which has been breaking the connection to the Staffware SPOs.

Resolves: https://companieshouse.atlassian.net/browse/CM-744