### PR TITLE
Compile watcher class as part of docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN mkdir -p ${SSO_HOME}/libs && \
     curl ${ARTIFACTORY_BASE_URL}/libs-release/com/staffware/libssoJNI/11.4.1/libssoJNI-11.4.1.so -o libssoJNI.so && \
     curl ${ARTIFACTORY_BASE_URL}/libs-release/com/staffware/ssoRMI/11.4.1/ssoRMI-11.4.1.jar -o ssoRMI.jar && \
     curl ${ARTIFACTORY_BASE_URL}/local-ch-release/com/oracle/weblogic/wlthint3client/12.2.1.4/wlthint3client-12.2.1.4.jar -o wlthint3client.jar && \
-    chmod 750 ${SSO_HOME}/*.sh
+    cd && /usr/java/jdk-8/bin/javac Watcher.java && \
+    chmod 750 *.sh
 
 CMD ["bash"]

--- a/ssodaemon/ssodaemon.sh
+++ b/ssodaemon/ssodaemon.sh
@@ -17,9 +17,6 @@ CLASS=com.staffware.sso.rmi.rsServerFactoryImpl
 # Set the vars in the jndi.properties file
 envsubst < jndi.properties.template > jndi.properties
 
-# Compile the Watcher class
-/usr/java/jdk-8/bin/javac Watcher.java 
-
 LOGS_DIR=/sso/logs/ssodaemon
 mkdir -p ${LOGS_DIR}
 LOG_FILE="${LOGS_DIR}/${HOSTNAME}-ssodaemon-$(date +'%Y-%m-%d_%H-%M-%S').log"

--- a/ssodaemon/watcher.sh
+++ b/ssodaemon/watcher.sh
@@ -19,7 +19,7 @@ do
   # Check for java SSOServerFactory process
   SSO_PID=$(ps -ef | grep SSOServerFactory | grep -v grep | awk '{print $2}')
 
-  if [ ${SSO_PID}x == "x" ]; then
+  if [ -z "${SSO_PID}" ]; then
     echo "Watcher: no SSOServerFactory process found, so exiting.."
     exit 0
   fi


### PR DESCRIPTION
Compile the java Watcher class as part of the docker build instead of when running the ssodaemon.sh script, so that any compile errors can be caught at build time instead of runtime.
Also adjusted the check for the SSO_PID var in watcher.sh to make it more robust.

Resolves: https://companieshouse.atlassian.net/browse/CM-744